### PR TITLE
README: fix install config snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following source configuration file will sync all data points for `mywebsite
 kind: source
 spec:
   name: "simple-analytics"
-  path: "simple-analytics/simple-analytics"
+  path: "simpleanalytics/simpleanalytics"
   version: "v2.0.0"
   # use this to enable incremental syncing
   # backend_options:


### PR DESCRIPTION
Looks like it is `simple-analytics/simple-analytics` for the Cloudquery Hub but `simpleanalytics/simpleanalytics` for GitHub.